### PR TITLE
Dimmu311 patch 1

### DIFF
--- a/modbus/modbus-in/modbus-in.hni
+++ b/modbus/modbus-in/modbus-in.hni
@@ -119,7 +119,7 @@
                     modbusTypeField.append($("<option></option>").val("Coil").text("Coil"));
                     modbusTypeField.append($("<option></option>").val("DiscI").text("DiscI"));
                     var nameLabel = $('<span/>',{class:"node-input-register-name-label"}).text(" "+nameLabelText+" ").appendTo(row);
-                    var nameField = $('<input/>',{class:"node-input-register-name",type:"text",maxlength:"5",style:"margin-left: 5px; width: 60px;"}).appendTo(row);
+                    var nameField = $('<input/>',{class:"node-input-register-name",type:"text",maxlength:"50",style:"margin-left: 5px; width: 60px;"}).appendTo(row);
                     var indexLabel = $('<span/>',{class:"node-input-register-index-label"}).text(" "+indexLabelText+" ").appendTo(row);
                     var indexField = $('<input/>',{class:"node-input-register-index",type:"text",style:"margin-left: 5px; width: 60px;"}).appendTo(row);
                     var countLabel = $('<span/>',{class:"node-input-register-count-label"}).text(" "+countLabelText+" ").appendTo(row);

--- a/modbus/modbus-out/modbus-out.hni
+++ b/modbus/modbus-out/modbus-out.hni
@@ -110,7 +110,7 @@
                     modbusTypeField.append($("<option></option>").val("Reg.").text("Reg."));
                     modbusTypeField.append($("<option></option>").val("Coil").text("Coil"));
                     var nameLabel = $('<span/>',{class:"node-input-register-name-label"}).text(" "+nameLabelText+" ").appendTo(row);
-                    var nameField = $('<input/>',{class:"node-input-register-name",type:"text",maxlength:"5",style:"margin-left: 5px; width: 60px;"}).appendTo(row);
+                    var nameField = $('<input/>',{class:"node-input-register-name",type:"text",maxlength:"50",style:"margin-left: 5px; width: 60px;"}).appendTo(row);
                     var indexLabel = $('<span/>',{class:"node-input-register-index-label"}).text(" "+indexLabelText+" ").appendTo(row);
                     var indexField = $('<input/>',{class:"node-input-register-index",type:"text",style:"margin-left: 5px; width: 60px;"}).appendTo(row);
                     var countLabel = $('<span/>',{class:"node-input-register-count-label"}).text(" "+countLabelText+" ").appendTo(row);


### PR DESCRIPTION
this increased maximum text length in node-input-register-name to set names witch more than 5 chars.
i think this could be useful because registernames in most modbus devices have longer names. 